### PR TITLE
Specify python_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,4 +70,5 @@ setup(
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
+    python_requires='>=3.6',
 )


### PR DESCRIPTION
When I try to run the example, I encounter error
```
  File ".../3.5/lib/python/site-packages/flask_redisboard/redisboard.py", line 178
    db_summary = server.keyspace.get(f"db{db}", dict())
                                             ^
SyntaxError: invalid syntax
```
which is due to usage of f-string feature which is only supported as from Python 3.6.

So it may be good to specify `python_requires` in your `setup.py` so users know what Python version they are supposed to use