### PR TITLE
fix The Flask-RedisBoard requires the 'SECRET_KEY' config var to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,19 @@ board = RedisBoardExtension(app)
 Also support for factory pattern:
 ```
 from flask_redisboard import RedisBoardExtension
+from flask import Flask
 board = RedisBoardExtension()
+
 
 def create_app():
     app = Flask(__name__)
-    ...
+    app.config['SECRET_KEY'] = '123456'
     board.init_app(app)
+    app.run()
+
+
+if __name__ == '__main__':
+    create_app()
 ```
 
 Now, you can go to 127.0.0.1:5000/redisboard 


### PR DESCRIPTION
fix The Flask-RedisBoard requires the 'SECRET_KEY' config var to be set